### PR TITLE
Renamed Type Adapter

### DIFF
--- a/ElectricalAppliances/src/ElectricalAppliances.Console/TypeGToAAdapter.cs
+++ b/ElectricalAppliances/src/ElectricalAppliances.Console/TypeGToAAdapter.cs
@@ -2,8 +2,8 @@
 
 namespace ElectricalAppliances.Console
 {
-    // UK to USA Adapter 
-    public class TypeAToGAdapter : ITypeAPluggableAppliance
+    // UK (Type G) to USA (Type A) Adapter 
+    public class TypeGToAAdapter : ITypeAPluggableAppliance
     {
         private readonly ITypeGPluggableAppliance appliance;
 


### PR DESCRIPTION
The class name says that the adapter is TypeAToGAdapter, but in the comment, there is a note that the adapter is UK to USA. But UK is type G and USA is type A. So I think this might not be very clear, so I created this PR.