### PR TITLE
Renamed Type Adapter

### DIFF
--- a/ElectricalAppliances/src/ElectricalAppliances.Console/TypeGToAAdapter.cs
+++ b/ElectricalAppliances/src/ElectricalAppliances.Console/TypeGToAAdapter.cs
@@ -2,8 +2,8 @@
 
 namespace ElectricalAppliances.Console
 {
-    // UK to USA Adapter 
-    public class TypeAToGAdapter : ITypeAPluggableAppliance
+    // UK (Type G) to USA (Type A) Adapter 
+    public class TypeGToAAdapter : ITypeAPluggableAppliance
     {
         private readonly ITypeGPluggableAppliance appliance;
 


### PR DESCRIPTION
Hello, I think that Adapter is wrongly named. Because we need to convert our object to type A not to type G.